### PR TITLE
Autoload expand-region integration

### DIFF
--- a/evil-iedit-state.el
+++ b/evil-iedit-state.el
@@ -150,6 +150,7 @@ If INTERACTIVE is non-nil then COMMAND is called interactively."
   (evil-paste-before count))
 
 ;; expand-region integration, add an "e" command
+;;;###autoload
 (eval-after-load 'expand-region
   '(progn
      (defun evil-iedit-state/iedit-mode-from-expand-region (&optional arg)


### PR DESCRIPTION
This adds the keybinding on expand-region load, even if evil-iedit-state is not yet loaded.

At least, that's what I think will happen.

Fixes https://github.com/syl20bnr/spacemacs/issues/3110.
