### PR TITLE
Bind "TAB" in addition to [tab]

### DIFF
--- a/evil-iedit-state.el
+++ b/evil-iedit-state.el
@@ -225,8 +225,9 @@ the initial string globally."
 (define-key evil-iedit-state-map "V"   'iedit-toggle-unmatched-lines-visible)
 (define-key evil-iedit-state-map "U"   'iedit-upcase-occurrences)
 (define-key evil-iedit-state-map (kbd "C-U") 'iedit-downcase-occurrences)
-(define-key evil-iedit-state-map (kbd "C-g")'evil-iedit-state/quit-iedit-mode)
-(define-key evil-iedit-state-map [tab] 'iedit-toggle-selection)
+(define-key evil-iedit-state-map (kbd "C-g") 'evil-iedit-state/quit-iedit-mode)
+(define-key evil-iedit-state-map (kbd "TAB") 'iedit-toggle-selection)
+(define-key evil-iedit-state-map [tab]       'iedit-toggle-selection)
 (define-key evil-iedit-state-map [backspace] 'iedit-blank-occurrences)
 (define-key evil-iedit-state-map [escape]    'evil-iedit-state/quit-iedit-mode)
 


### PR DESCRIPTION
Without this change TAB doesn't work for me in terminal emacs - it's bound to `iedit-next-occurrence (found in iedit-mode-keymap)`

I see that yasnippet (https://github.com/joaotavora/yasnippet/blob/master/yasnippet.el#L395) binds both so maybe this is the way to address this issue.

BTW Thank you for this package!