### PR TITLE
Override yank handlers when pasting

### DIFF
--- a/evil-iedit-state.el
+++ b/evil-iedit-state.el
@@ -152,7 +152,7 @@ If INTERACTIVE is non-nil then COMMAND is called interactively."
   "Replace the selection with the yanked text."
   (interactive "P")
   (when kill-ring (iedit-delete-occurrences))
-  (evil-paste-before count))
+  (evil-paste-before count nil '(#'insert-as-yank)))
 
 ;; expand-region integration, add an "e" command
 ;;;###autoload


### PR DESCRIPTION
Override yank handlers when pasting

The pasted text may specify a yank handler, e.g., `evil-yank-line-handler`, that inserts the text outside of the current overlay.  It is necessary to override any such yank handler in order to ensure that the text replaces the current overlay and gets propagated to the other overlays.

* `evil-iedit-state.el` (`evil-iedit-state/paste-replace`): Specify `insert-for-yank` as the yank handler when calling `evil-paste-before`.

Thanks to @duianto for identifying the problem (see https://github.com/syl20bnr/spacemacs/pull/9253#issuecomment-317193516)!