### PR TITLE
iedit-cleanup -> iedit-lib-cleanup?

### DIFF
--- a/evil-iedit-state.el
+++ b/evil-iedit-state.el
@@ -191,7 +191,7 @@ the initial string globally."
   ;; (kill-new iedit-last-occurrence-local)) ; Make occurrence the latest kill in the kill ring.
   (setq iedit-num-lines-to-expand-up 0)
   (setq iedit-num-lines-to-expand-down 0)
-  (iedit-cleanup)
+  (iedit-lib-cleanup)
   (setq iedit-initial-string-local nil)
   (setq iedit-mode nil)
   (force-mode-line-update)


### PR DESCRIPTION
A call to iedit-cleanup in iedit-done seems to cause "Symbol's function definition is void: iedit-cleanup" in 0.300.0@26.3 (spacemacs) when trying to exit iedit-mode (ESC-ESC or C-g). The ".emacs.d" is under "develop".

If iedit-cleanup is replaced with iedit-lib-cleanup and iedit-done re-evaluated, the issue is gone.

Hope this is useful. Thank you!