### PR TITLE
Disable AHS mode when exiting evil-iedit-mode

### DIFF
--- a/evil-iedit-state.el
+++ b/evil-iedit-state.el
@@ -57,7 +57,8 @@
 (defun evil-iedit-state/iedit-mode (&optional arg)
   "Start `iedit-mode'."
   (interactive "P")
-  (if (fboundp 'ahs-clear) (ahs-clear))
+  (when (fboundp 'auto-highlight-symbol-mode)
+    (auto-highlight-symbol-mode -1))
   (iedit-mode arg)
   (evil-iedit-state))
 


### PR DESCRIPTION
problem
If `auto-highlight-symbol-mode` (AHS) was enabled before entering `evil-iedit-mode`.
When exiting `evil-iedit-mode`, then the AHS highlight just gets cleared.
But AHS mode is still enabled.

Trying to enable AHS shows the message:
>automatic-symbol-highlight disabled.

AHS mode has to be toggled a second time to enable it.

solution
Disable AHS mode when exiting `evil-iedit-mode`, it also clears the AHS highlight.