### PR TITLE
Modernize advice definition using advice-add

### DIFF
--- a/evil-iedit-state.el
+++ b/evil-iedit-state.el
@@ -166,15 +166,14 @@ If INTERACTIVE is non-nil then COMMAND is called interactively."
        ;; force expand-region temporary overlay map exit
        (setq overriding-terminal-local-map nil))
 
-     (defadvice er/prepare-for-more-expansions-internal
-         (around iedit/prepare-for-more-expansions-internal activate)
-       ad-do-it
-       (let ((default-msg (car ad-return-value))
-             (default-bindings (cdr ad-return-value)))
-         (setq ad-return-value
-               (cons (concat default-msg ", e to edit")
-                     (add-to-list 'default-bindings
-                                  '("e" evil-iedit-state/iedit-mode-from-expand-region))))))))
+     (advice-add 'er/prepare-for-more-expansions-internal :around
+                 (lambda (orig-fun &rest args)
+                   (let ((result (apply orig-fun args)))
+                     (let ((default-msg (car result))
+                           (default-bindings (cdr result)))
+                       (cons (concat default-msg ", e to edit")
+                             (add-to-list 'default-bindings
+                                         '("e" evil-iedit-state/iedit-mode-from-expand-region)))))))))
 
 ;; redefine iedit-done to prevent iedit from putting the occurrence on the
 ;; kill-ring for no useful reason.

--- a/evil-iedit-state.el
+++ b/evil-iedit-state.el
@@ -166,14 +166,14 @@ If INTERACTIVE is non-nil then COMMAND is called interactively."
        ;; force expand-region temporary overlay map exit
        (setq overriding-terminal-local-map nil))
 
-     (advice-add 'er/prepare-for-more-expansions-internal :around
-                 (lambda (orig-fun &rest args)
-                   (let ((result (apply orig-fun args)))
-                     (let ((default-msg (car result))
-                           (default-bindings (cdr result)))
-                       (cons (concat default-msg ", e to edit")
-                             (add-to-list 'default-bindings
-                                         '("e" evil-iedit-state/iedit-mode-from-expand-region)))))))))
+     (define-advice er/prepare-for-more-expansions-internal
+         (:around (orig-fun &rest args) evil-iedit-state)
+       (let* ((result (apply orig-fun args))
+              (default-msg (car result))
+              (default-bindings (cdr result)))
+         (cons (concat default-msg ", e to edit")
+               (add-to-list 'default-bindings
+                            '("e" evil-iedit-state/iedit-mode-from-expand-region)))))))
 
 ;; redefine iedit-done to prevent iedit from putting the occurrence on the
 ;; kill-ring for no useful reason.


### PR DESCRIPTION
# Description
Modernized the advice definition by replacing the old `defadvice` form with the modern `define-advice` syntax.

## Changes
- Replaced `defadvice` with `define-advice` for `er/prepare-for-more-expansions-internal`
- Maintained same functionality using cleaner, modern syntax
- No behavioral changes, just modernization of code

## Testing Done
- Tested expand-region integration
- Verified "e to edit" message appears in minibuffer
- Confirmed iedit-mode activation works as expected
- Tested editing multiple occurrences

This change requires Emacs 24.4 or later (which is already required by the package dependencies).